### PR TITLE
fix: opening directories and add timeout to format on save

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ require("lazy").setup({
 			-- trunkPath = "trunk",
 			-- lspArgs = {},
 			-- formatOnSave = true,
+			-- formatOnSaveTimeout = 10, -- seconds
 			-- logLevel = "info"
 		},
 		main = "trunk",

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ require("lazy").setup({
 			-- trunkPath = "trunk",
 			-- lspArgs = {},
 			-- formatOnSave = true,
-      -- formatOnSaveTimeout = 10, -- seconds
+                        -- formatOnSaveTimeout = 10, -- seconds
 			-- logLevel = "info"
 		},
 		main = "trunk",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ instructions below:
 
 - Minimum Neovim version: `v0.9.2`
 - Minimum Trunk CLI version: `1.16.3`
-- Some commands require `sed` and `tee` to be in `PATH`.
+- Some commands require `sed` and `tee` to be in `PATH`
+- Format on save timeout only works on UNIX and if coreutils `timeout` is in `PATH`
 
 ### [lazy.nvim](https://github.com/folke/lazy.nvim)
 
@@ -50,6 +51,7 @@ require("lazy").setup({
 			-- trunkPath = "trunk",
 			-- lspArgs = {},
 			-- formatOnSave = true,
+      -- formatOnSaveTimeout = 10, -- seconds
 			-- logLevel = "info"
 		},
 		main = "trunk",
@@ -99,6 +101,7 @@ return require("packer").startup(function(use)
       -- trunkPath = "trunk",
       -- formatOnSave = true,
       -- lspArgs = {},
+      -- formatOnSaveTimeout = 10, -- seconds
 			-- logLevel = "info"
     }) end
   }
@@ -125,6 +128,7 @@ require "paq" {
       -- logLevel = "debug",
       -- trunkPath = "trunk",
       -- formatOnSave = false,
+      -- formatOnSaveTimeout = 10, -- seconds
       -- lspArgs = {}
     }) end,
     branch = "v0.1.0",
@@ -156,12 +160,13 @@ Other commands:
 
 The neovim extension can be configured as follows:
 
-| Option       | Configures                                             | Default |
-| ------------ | ------------------------------------------------------ | ------- |
-| trunkPath    | Where to find the Trunk CLI launcher of binary         | "trunk" |
-| lspArgs      | Optional arguments to append the Trunk LSP Server      | {}      |
-| formatOnSave | Whether or not to autoformat file buffers when written | true    |
-| logLevel     | Verbosity of logs from the Neovim extension            | "info"  |
+| Option              | Configures                                                               | Default |
+| ------------------- | ------------------------------------------------------------------------ | ------- |
+| trunkPath           | Where to find the Trunk CLI launcher of binary                           | "trunk" |
+| lspArgs             | Optional arguments to append the Trunk LSP Server                        | {}      |
+| formatOnSave        | Whether or not to autoformat file buffers when written                   | true    |
+| formatOnSaveTimeout | The maximum amount of time to spend attempting to autoformat, in seconds | 10      |
+| logLevel            | Verbosity of logs from the Neovim extension                              | "info"  |
 
 (These settings can be changed after loading by calling `require("neovim-trunk").setup({})`)
 

--- a/lua/trunk.lua
+++ b/lua/trunk.lua
@@ -312,7 +312,7 @@ local function setup(opts)
 	end
 
 	if not isempty(opts.formatOnSaveTimeout) then
-		logger.debug("Overrode formatOnSave with", opts.formatOnSaveTimeout)
+		logger.debug("Overrode formatOnSaveTimeout with", opts.formatOnSaveTimeout)
 		formatOnSave = opts.formatOnSaveTimeout
 	end
 end


### PR DESCRIPTION
No longer crashes on opening a directory. Additionally, adds a config variable `formatOnSaveTimeout` to timeout long format on save on unix systems with timeout in path.