### PR TITLE
fix: assorted format on save fixes

### DIFF
--- a/lua/trunk.lua
+++ b/lua/trunk.lua
@@ -257,7 +257,7 @@ local function start()
 				local cursor = vim.api.nvim_win_get_cursor(0)
 				local filename = vim.api.nvim_buf_get_name(0)
 				local workspace = findWorkspace()
-				-- if filename starts with workspace
+				-- if filename doesn't start with workspace
 				if filename:sub(1, #workspace) ~= workspace then
 					logger.debug("early exit")
 					return


### PR DESCRIPTION
Fixes:
* Actually respects timeout (a typo previously prevented timeout from working at all)
* Only runs format on save on files inside the workspace
* Now writes the format on save output to a file, and then only outputs it if it ran successfully - previously, if there was an error, the error output would get written to the file, followed by the text of the file
* Now puts the cursor at the bottom line (rather than erroring) if formatting the file would reduce the number of lines to less than where the cursor currently is