### PR TITLE
Bump cli version in docs

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 1.16.3-beta.3
+  version: 1.17.0
   options:
     - commands: [upgrade]
       args: -y --no-progress

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ instructions below:
 ### Prerequisites
 
 - Minimum Neovim version: `v0.9.2`
-- Minimum Trunk CLI version: `1.16.3`
+- Minimum Trunk CLI version: `1.17.0`
 - Some commands require `sed` and `tee` to be in `PATH`
 - Format on save timeout only works on UNIX and if coreutils `timeout` is in `PATH`
 


### PR DESCRIPTION
1.17.0 was released, so recommend that as the minimum version, and upgrade Trunk in the repo