### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Extension][vscode]. The Neovim plugin has the following capabilities:
 `neovim-trunk` can be installed using your favorite Neovim plugin manager. We've included some
 instructions below:
 
+_Note: Some plugin managers offer varying capabilities for configuration and pinning refs_
+
 ### Prerequisites
 
 - Minimum Neovim version: `v0.9.2`
 - Minimum Trunk CLI version: `1.17.0`
 - Some commands require `sed` and `tee` to be in `PATH`
 - Format on save timeout only works on UNIX and if coreutils `timeout` is in `PATH`
-
-_Note: Some plugin managers offer varying capabilities for configuration and pinning refs_
 
 ### [lazy.nvim](https://github.com/folke/lazy.nvim)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Extension][vscode]. The Neovim plugin has the following capabilities:
 `neovim-trunk` can be installed using your favorite Neovim plugin manager. We've included some
 instructions below:
 
-<!-- trunk-ignore(markdownlint/MD036) -->
+<!-- trunk-ignore-all(markdownlint/MD036) -->
 
 _Note: Some plugin managers offer varying capabilities for configuration and pinning refs_
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ require("lazy").setup({
 call plug#begin()
 
 " Required dependencies
-Plug "nvim-telescope/telescope.nvim"
-Plug "nvim-lua/plenary.nvim"
+Plug 'nvim-telescope/telescope.nvim'
+Plug 'nvim-lua/plenary.nvim'
 
-Plug "trunk-io/neovim-trunk", { "tag": "*" }
+Plug 'trunk-io/neovim-trunk', { 'tag': '*' }
 
 call plug#end()
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Extension][vscode]. The Neovim plugin has the following capabilities:
 `neovim-trunk` can be installed using your favorite Neovim plugin manager. We've included some
 instructions below:
 
+<!-- trunk-ignore(markdownlint/MD036) -->
+
 _Note: Some plugin managers offer varying capabilities for configuration and pinning refs_
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ instructions below:
 - Some commands require `sed` and `tee` to be in `PATH`
 - Format on save timeout only works on UNIX and if coreutils `timeout` is in `PATH`
 
+_Note: Some plugin managers offer varying capabilities for configuration and pinning refs_
+
 ### [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 1. Follow the [lazy.nvim install instructions](https://github.com/folke/lazy.nvim#-installation) to
@@ -45,7 +47,7 @@ require("lazy").setup({
 	{
 		"trunk-io/neovim-trunk",
 		lazy = false,
-		tag = "*",
+		tag = "v0.1.0",
 		-- these are optional config arguments (defaults shown)
 		config = {
 			-- trunkPath = "trunk",
@@ -131,7 +133,6 @@ require "paq" {
       -- formatOnSaveTimeout = 10, -- seconds
       -- lspArgs = {}
     }) end,
-    branch = "v0.1.0",
   }
 }
 ```

--- a/lua/trunk.lua
+++ b/lua/trunk.lua
@@ -341,7 +341,7 @@ local function setup(opts)
 	end
 
 	if not isempty(opts.trunkPath) then
-		logger.debug("Overrode trunkPath with" .. opts.trunkPath)
+		logger.debug("Overrode trunkPath with " .. opts.trunkPath)
 		trunkPath = opts.trunkPath
 	end
 


### PR DESCRIPTION
Some of the plugin managers have limitations we weren't aware of. Also some of our syntax was slightly off.