### PR TITLE
fix: add --output-file to fmt on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,13 @@ Plug 'nvim-lua/plenary.nvim'
 Plug 'trunk-io/neovim-trunk', { 'tag': '*' }
 
 call plug#end()
+
+lua require'trunk'.setup({})
 ```
 
-3. Call `:PlugInstall` to install and `:PlugStatus` to verify
-4. Close and relaunch Neovim to start running Trunk
-
-_Note: Currently we do not support overriding configuration options using vim-plug._
+3. Add settings to the `setup` command as desired.
+4. Call `:PlugInstall` to install and `:PlugStatus` to verify
+5. Close and relaunch Neovim to start running Trunk
 
 ### [packer.nvim](https://github.com/wbthomason/packer.nvim)
 

--- a/plugin/trunk.vim
+++ b/plugin/trunk.vim
@@ -8,9 +8,6 @@ function! OpenConfig()
   execute 'edit '.fnameescape(configFile)
 endfunction
 
-" command to run our plugin
-lua require'trunk'.start()
-
 " command to open trunk.yaml
 command! TrunkConfig :call OpenConfig()
 


### PR DESCRIPTION
Uses `--output-file` to do format on save, so we no longer write logs to the file if the trunk launcher outputs logs (e.g. if trunk is called through bazel).

This will not work until a new prod release for the CLI is out - the current CLI version that includes the `--output-file` fix is `1.17.2-beta.5`, which is technically less than `1.17.2`

Testing for this PR also exposed a bug where `setup` was being called after `start` - this PR reworks that flow, causing `setup` to call `start`. As a side-effect, we can now support setup configs via VimPlug.

This includes syntax for windows, although it's untested.