### PR TITLE
Add commands for custom code action callbacks

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -6,3 +6,4 @@
 plugins
 user_trunk.yaml
 user.yaml
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,20 +1,20 @@
 version: 0.1
 cli:
-  version: 1.17.2-beta.5
+  version: 1.18.2-beta.14
   options:
     - commands: [upgrade]
       args: -y --no-progress
 plugins:
   sources:
     - id: trunk
-      ref: v1.2.5
+      ref: v1.4.1
       uri: https://github.com/trunk-io/plugins
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v0.0.7
+      ref: v1.0.1
 lint:
   enabled:
-    - stylua@0.18.2
+    - stylua@0.19.1
   ignore:
     - linters: [ALL]
       paths: [lsp*]

--- a/lua/trunk.lua
+++ b/lua/trunk.lua
@@ -256,6 +256,32 @@ local function connect()
 					-- TODO(Tyler): Conditionally add a progress bar pane?
 				end,
 			},
+			-- custom callbacks for commands from code actions
+			commands = {
+				["trunk.checkEnable"] = function(command, _client_info, _command_str, _args)
+					-- TODO(Tyler): Use non-ANSI mode
+					vim.cmd(
+						"!"
+							.. table.concat(executionTrunkPath(), " ")
+							.. " check enable "
+							.. table.concat(command["arguments"])
+							.. [[ | sed -e 's/\x1b\[[0-9;]*m//g']]
+					)
+				end,
+				["trunk.checkDisable"] = function(command, _client_info, _command_str, _args)
+					-- TODO(Tyler): Use non-ANSI mode
+					vim.cmd(
+						"!"
+							.. table.concat(executionTrunkPath(), " ")
+							.. " check disable "
+							.. table.concat(command["arguments"])
+							.. [[ | sed -e 's/\x1b\[[0-9;]*m//g']]
+					)
+				end,
+				["trunk.openConfigFile"] = function(_command, _client_info, _command_str, _args)
+					vim.cmd(":edit " .. findConfig())
+				end,
+			},
 		})
 	end
 end


### PR DESCRIPTION
In recent CLI versions, LSP will suggest code actions for enabling/disabling linters and opening the Trunk config. By registering commands to the [`commands`](https://neovim.io/doc/user/lsp.html#vim.lsp.commands) table, we can provide callbacks for these.

Atm we don't have a non-ANSI coloring mode so we strip the output again with `sed`.

This approach will likely not be feasible for `emacs` since if the commands don't exist it will attempt to execute them on the command line IIRC.