### PR TITLE
fix: don't attach trunk to non-normal buffers

### DIFF
--- a/lua/trunk.lua
+++ b/lua/trunk.lua
@@ -322,6 +322,10 @@ local function start()
 	autocmd("FileType", {
 		pattern = "*",
 		callback = function()
+			local bt = vim.bo.buftype
+			if bt ~= "" then -- ignore every non‑normal buffer
+				return
+			end
 			local bufname = vim.api.nvim_buf_get_name(0)
 			logger.debug("Buffer filename: " .. bufname)
 			local fs = vim.fs


### PR DESCRIPTION
When using snacks.nvim picker, trunk was attaching when showing the picker. It would cause trunk to timeout (3s timeout in my case) which delayed showing the picker for 3s.

If there is a different want to fix this without a code change please let me know.